### PR TITLE
Auto generation interface

### DIFF
--- a/sros2/sros2/policy/__init__.py
+++ b/sros2/sros2/policy/__init__.py
@@ -64,13 +64,18 @@ def load_policy(policy_file_path):
             "policy file '%s' does not exist" % policy_file_path)
     policy = etree.parse(policy_file_path)
     policy.xinclude()
+    assert_valid_policy(policy)
+    return policy
+
+
+def assert_valid_policy(policy):
+    """Assert the validity of the policy. Throw a RuntimeError if not valid."""
     try:
         policy_xsd_path = get_policy_schema('policy.xsd')
         policy_xsd = etree.XMLSchema(etree.parse(policy_xsd_path))
         policy_xsd.assertValid(policy)
     except etree.DocumentInvalid as e:
         raise RuntimeError(str(e))
-    return policy
 
 
 def dump_policy(policy, stream):

--- a/sros2/sros2/verb/amend_policy.py
+++ b/sros2/sros2/verb/amend_policy.py
@@ -126,6 +126,7 @@ class AmendPolicyVerb(VerbExtension):
             default=int(9999), type=int,
             help='a duration for monitoring the events (seconds)')
 
+    @staticmethod
     def get_policy(policy_file_path):
         """Return a policy tree from the path or an empty policy tree if it doesn't exist."""
         if os.path.isfile(policy_file_path):
@@ -270,9 +271,7 @@ class AmendPolicyVerb(VerbExtension):
 
     def main(self, *, args):
         try:
-            self.policy = load_policy(args.policy_file_path)
-        except FileNotFoundError:
-            return POLICY_FILE_NOT_FOUND
+            self.policy = self.get_policy(args.policy_file_path)
         except RuntimeError:
             return POLICY_FILE_NOT_VALID
 

--- a/sros2/sros2/verb/amend_policy.py
+++ b/sros2/sros2/verb/amend_policy.py
@@ -127,7 +127,7 @@ class AmendPolicyVerb(VerbExtension):
             help='a duration for monitoring the events (seconds)')
 
     def get_policy(policy_file_path):
-        """Return a policy tree from the path or an empty policy tree if it doens't exist."""
+        """Return a policy tree from the path or an empty policy tree if it doesn't exist."""
         if os.path.isfile(policy_file_path):
             return load_policy(policy_file_path)
         else:

--- a/sros2/test/policies/dummy_policy.xml
+++ b/sros2/test/policies/dummy_policy.xml
@@ -1,24 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<policy version="0.1.0"
-  xmlns:xi="http://www.w3.org/2001/XInclude">
+<policy xmlns:xi="http://www.w3.org/2001/XInclude" version="0.1.0">
   <profiles>
-    <profile ns='/ns' node='foo_node'>
-      <topics publish="ALLOW" subscribe="ALLOW" >
+    <profile node="node" ns="/ns">
+      <topics subscribe="ALLOW">
         <topic>parameter_events</topic>
       </topics>
-
-      <topics publish="DENY" >
-        <topic>denied_topic</topic>
-      </topics>
-
-      <services reply="ALLOW" request="ALLOW" >
-        <service>~describe_parameters</service>
-        <service>~get_parameter_types</service>
-        <service>~get_parameters</service>
-        <service>~list_parameters</service>
-        <service>~set_parameters</service>
-        <service>~set_parameters_atomically</service>
-      </services>
     </profile>
   </profiles>
 </policy>

--- a/sros2/test/policies/expected_dummy_policy.xml
+++ b/sros2/test/policies/expected_dummy_policy.xml
@@ -1,0 +1,22 @@
+<policy xmlns:xi="http://www.w3.org/2001/XInclude" version="0.1.0">
+  <profiles>
+    <profile node="node" ns="/ns">
+      <services reply="ALLOW">
+        <service>~describe_parameters</service>
+        <service>~get_parameter_types</service>
+        <service>~get_parameters</service>
+        <service>~list_parameters</service>
+        <service>~set_parameters</service>
+        <service>~set_parameters_atomically</service>
+      </services>
+      <topics subscribe="ALLOW">
+        <topic>parameter_events</topic>
+      </topics>
+      <topics publish="ALLOW">
+        <topic>denied_topic</topic>
+        <topic>parameter_events</topic>
+        <topic>rosout</topic>
+      </topics>
+    </profile>
+  </profiles>
+</policy>

--- a/sros2/test/sros2/commands/security/verbs/test_amend_policy_cli.py
+++ b/sros2/test/sros2/commands/security/verbs/test_amend_policy_cli.py
@@ -58,31 +58,6 @@ def test_ament_policy():
             node.destroy_node()
             rclpy.shutdown(context=context)
 
-    # # Load the policy and pull out the allowed publications and subscriptions
-    # policy = load_policy(os.path.join(tmpdir, 'test-policy.xml'))
-    # profile = policy.find(path='profiles/profile[@ns="/"][@node="test_node"]')
-    # assert profile is not None
-    # topics_publish_allowed = profile.find(path='topics[@publish="ALLOW"]')
-    # assert topics_publish_allowed is not None
-    # topics_subscribe_allowed = profile.find(path='topics[@subscribe="ALLOW"]')
-    # assert topics_subscribe_allowed is not None
-    #
-    # # Verify that the allowed publications include topic_pub and not topic_sub
-    # topics = topics_publish_allowed.findall('topic')
-    # assert len([t for t in topics if t.text == 'topic_pub']) == 1
-    # assert len([t for t in topics if t.text == 'topic_sub']) == 0
-    #
-    # # Verify that the allowed subscriptions include topic_sub and not topic_pub
-    # topics = topics_subscribe_allowed.findall('topic')
-    # assert len([t for t in topics if t.text == 'topic_sub']) == 1
-    # assert len([t for t in topics if t.text == 'topic_pub']) == 0
-
-
-def test_amend_policy_no_file(capsys):
-    assert cli.main(argv=[
-        'security', 'amend_policy', os.path.join('', 'bar.xml')]) == \
-            'Package policy file not found'
-
 
 def test_amend_policy_file_not_valid(capsys):
     assert cli.main(argv=[


### PR DESCRIPTION
- Improve test comparing a tmp generated policy file against an expected one.
- use `AmendPolicyVerb.get_policy` so that if policy file doesn't exists it still creates a new tree
- Some cleanup